### PR TITLE
Add more parameters

### DIFF
--- a/email.php
+++ b/email.php
@@ -75,14 +75,25 @@ class EmailPlugin extends Plugin
                 } else {
                     $to = (array) $this->config->get('plugins.email.to');
                 }
+
+                if (!empty($params['reply_to'])) {
+                    $replyTo = $twig->processString($params['reply_to'], $vars);
+                } else {
+                    $replyTo = $this->config->get('plugins.email.reply_to');
+                }
+
                 $subject = !empty($params['subject']) ?
                     $twig->processString($params['subject'], $vars) : $form->page()->title();
+
                 $body = !empty($params['body']) ?
                     $twig->processString($params['body'], $vars) : '{% include "forms/data.html.twig" %}';
 
                 $message = $this->email->message($subject, $body)
                     ->setFrom($from)
                     ->setTo($to);
+                if (!empty($replyTo)) {
+                    $message->setReplyTo($replyTo);
+                }
 
                 $this->email->send($message);
 

--- a/email.php
+++ b/email.php
@@ -88,7 +88,14 @@ class EmailPlugin extends Plugin
                 $body = !empty($params['body']) ?
                     $twig->processString($params['body'], $vars) : '{% include "forms/data.html.twig" %}';
 
-                $message = $this->email->message($subject, $body)
+                if (!empty($params['format'])) {
+                    $format = $twig->processString($params['format'], $vars);
+                } else {
+                    $format = $this->config->get('plugins.email.format');
+                }
+                $bodyType = ($format == 'html' ? 'text/html' : 'text/plain');
+
+                $message = $this->email->message($subject, $body, $bodyType)
                     ->setFrom($from)
                     ->setTo($to);
                 if (!empty($replyTo)) {

--- a/email.yaml
+++ b/email.yaml
@@ -1,6 +1,7 @@
 enabled: true
 from: ''
 to: ''
+format: html
 mailer:
   engine: mail
   smtp:


### PR DESCRIPTION
In order to send HTML mails, we need to set a proper `Content-Type`. This patch introduces a new parameter `format` to control this header.

In addition, I added a parameter for `Reply-To`. This especially useful in order to directly respond to form emails (e.g. `reply_to: "{{ form.values.youremail }}"`)