### PR TITLE
If no body parameter is specified, the default is not processed as Twig template

### DIFF
--- a/email.php
+++ b/email.php
@@ -77,8 +77,7 @@ class EmailPlugin extends Plugin
                 }
                 $subject = !empty($params['subject']) ?
                     $twig->processString($params['subject'], $vars) : $form->page()->title();
-                $body = !empty($params['body']) ?
-                    $twig->processString($params['body'], $vars) : '{% include "forms/data.html.twig" %}';
+                $body = $twig->processString(!empty($params['body']) ? $params['body'] : '{% include "forms/data.html.twig" %}', $vars);
 
                 $message = $this->email->message($subject, $body)
                     ->setFrom($from)


### PR DESCRIPTION
If no body parameter is specified in the form, the default setting applies.

However the default setting does generate an email with the literal string `{% include "forms/data.html.twig" %}` instead of processing the Twig template and generate the submission data.
