### PR TITLE
Rework e-mail message building and support for additional parameters

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -48,6 +48,12 @@ form:
         required: true
         type: email
 
+    from_name:
+      type: text
+      size: medium
+      label: Email from name
+      placeholder: "Default email from name"
+
     to:
       type: email
       size: medium

--- a/email.php
+++ b/email.php
@@ -86,6 +86,7 @@ class EmailPlugin extends Plugin
             'body' => '{% include "forms/data.html.twig" %}',
             'from' => $this->config->get('plugins.email.from'),
             'from_name' => $this->config->get('plugins.email.from_name'),
+            'content_type' => null,
             'subject' => !empty($vars['form']) && $vars['form'] instanceof Form ? $vars['form']->page()->title() : null,
             'to' => (array) $this->config->get('plugins.email.to'),
         );
@@ -98,6 +99,12 @@ class EmailPlugin extends Plugin
             switch ($key) {
                 case 'body':
                     $message->setBody($twig->processString($value, $vars));
+                    break;
+
+                case 'content_type':
+                    if (!empty($value)) {
+                        $message->setContentType($twig->processString($value, $vars));
+                    }
                     break;
 
                 case 'from':

--- a/email.php
+++ b/email.php
@@ -55,37 +55,67 @@ class EmailPlugin extends Plugin
 
         switch ($action) {
             case 'email':
-                /** @var Twig $twig */
-                $twig = $this->grav['twig'];
+                // Prepare Twig variables
                 $vars = array(
                     'form' => $form
                 );
 
-                if (!empty($params['from'])) {
-                    $from = $twig->processString($params['from'], $vars);
-                } else {
-                    $from = $this->config->get('plugins.email.from');
-                }
+                // Build message
+                $message = $this->buildMessage($params, $vars);
 
-                if (!empty($params['to'])) {
-                    $to = (array) $params['to'];
-                    foreach ($to as &$address) {
-                        $address = $twig->processString($address, $vars);
-                    }
-                } else {
-                    $to = (array) $this->config->get('plugins.email.to');
-                }
-                $subject = !empty($params['subject']) ?
-                    $twig->processString($params['subject'], $vars) : $form->page()->title();
-                $body = $twig->processString(!empty($params['body']) ? $params['body'] : '{% include "forms/data.html.twig" %}', $vars);
-
-                $message = $this->email->message($subject, $body)
-                    ->setFrom($from)
-                    ->setTo($to);
-
+                // Send e-mail
                 $this->email->send($message);
-
                 break;
         }
+    }
+
+    /**
+     * Build e-mail message.
+     *
+     * @param array $params
+     * @param array $vars
+     * @return \Swift_Message
+     */
+    protected function buildMessage(array $params, array $vars = array())
+    {
+        /** @var Twig $twig */
+        $twig = $this->grav['twig'];
+
+        // Extend parameters with defaults.
+        $params += array(
+            'body' => '{% include "forms/data.html.twig" %}',
+            'from' => $this->config->get('plugins.email.from'),
+            'subject' => !empty($vars['form']) && $vars['form'] instanceof Form ? $vars['form']->page()->title() : null,
+            'to' => (array) $this->config->get('plugins.email.to'),
+        );
+
+        // Create message object.
+        $message = $this->email->message();
+
+        // Process parameters.
+        foreach ($params as $key => $value) {
+            switch ($key) {
+                case 'body':
+                    $message->setBody($twig->processString($value, $vars));
+                    break;
+
+                case 'from':
+                    $message->setFrom($twig->processString($value, $vars));
+                    break;
+
+                case 'subject':
+                    $message->setSubject($twig->processString($value, $vars));
+                    break;
+
+                case 'to':
+                    $value = (array) $value;
+                    foreach ($value as &$address) {
+                        $message->addTo($twig->processString($address, $vars));
+                    }
+                    break;
+            }
+        }
+
+        return $message;
     }
 }

--- a/email.php
+++ b/email.php
@@ -85,6 +85,7 @@ class EmailPlugin extends Plugin
         $params += array(
             'body' => '{% include "forms/data.html.twig" %}',
             'from' => $this->config->get('plugins.email.from'),
+            'from_name' => $this->config->get('plugins.email.from_name'),
             'subject' => !empty($vars['form']) && $vars['form'] instanceof Form ? $vars['form']->page()->title() : null,
             'to' => (array) $this->config->get('plugins.email.to'),
         );
@@ -100,7 +101,8 @@ class EmailPlugin extends Plugin
                     break;
 
                 case 'from':
-                    $message->setFrom($twig->processString($value, $vars));
+                    $from_name = !empty($params['from_name']) ? $twig->processString($params['from_name'], $vars) : null;
+                    $message->setFrom($twig->processString($value, $vars), $from_name);
                     break;
 
                 case 'subject':

--- a/email.php
+++ b/email.php
@@ -87,6 +87,7 @@ class EmailPlugin extends Plugin
             'from' => $this->config->get('plugins.email.from'),
             'from_name' => $this->config->get('plugins.email.from_name'),
             'content_type' => null,
+            'reply_to' => array(),
             'subject' => !empty($vars['form']) && $vars['form'] instanceof Form ? $vars['form']->page()->title() : null,
             'to' => (array) $this->config->get('plugins.email.to'),
         );
@@ -110,6 +111,13 @@ class EmailPlugin extends Plugin
                 case 'from':
                     $from_name = !empty($params['from_name']) ? $twig->processString($params['from_name'], $vars) : null;
                     $message->setFrom($twig->processString($value, $vars), $from_name);
+                    break;
+
+                case 'reply_to':
+                    $value = (array) $value;
+                    foreach ($value as $address) {
+                        $message->addReplyTo($twig->processString($address, $vars));
+                    }
                     break;
 
                 case 'subject':


### PR DESCRIPTION
I just reworked the e-mail message building a little to easily allow support of additional parameters. Currently the following are added:

* Message content type
* Reply-To address(es)
* From/sender name

Perhaps there should also be added more parameters to be working out of the box. I am currently e.g. thinking of:

* CC
* BCC
* Read receipt
* Priority

I guess there is still some documentation work needed so users will recognize these new parameters, but I ignored that for now, to get your feedback first.