### PR TITLE
Config addons

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -58,7 +58,7 @@ form:
       type: email
       size: medium
       label: Email to
-      placeholder: "Default email to address (can also be comma separated list)"
+      placeholder: "Default email to address"
       validate:
         required: true
         type: email

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -39,6 +39,14 @@ form:
         sendmail: Sendmail
         mail: PHP Mail
 
+    content_type:
+      type: select
+      label: Content type
+      size: medium
+      options:
+        'text/plain': Plain text
+        'text/html': HTML
+
     from.mail:
       type: email
       size: medium

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -39,7 +39,7 @@ form:
         sendmail: Sendmail
         mail: PHP Mail
 
-    from:
+    from.mail:
       type: email
       size: medium
       label: Email from
@@ -48,7 +48,7 @@ form:
         required: true
         type: email
 
-    from_name:
+    from.name:
       type: text
       size: medium
       label: Email from name

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -54,7 +54,7 @@ form:
       label: Email from name
       placeholder: "Default email from name"
 
-    to:
+    to.mail:
       type: email
       size: medium
       label: Email to
@@ -62,6 +62,12 @@ form:
       validate:
         required: true
         type: email
+
+    to.name:
+      type: text
+      size: medium
+      label: Email to name
+      placeholder: "Default email to name"
 
     mailer.smtp.server:
       type: text

--- a/email.php
+++ b/email.php
@@ -97,8 +97,20 @@ class EmailPlugin extends Plugin
         // Process parameters.
         foreach ($params as $key => $value) {
             switch ($key) {
+                case 'bcc':
+                    foreach ($this->parseAddressValue($value, $vars) as $address) {
+                        $message->addBcc($address->mail, $address->name);
+                    }
+                    break;
+
                 case 'body':
                     $message->setBody($twig->processString($value, $vars));
+                    break;
+
+                case 'cc':
+                    foreach ($this->parseAddressValue($value, $vars) as $address) {
+                        $message->addCc($address->mail, $address->name);
+                    }
                     break;
 
                 case 'content_type':

--- a/email.php
+++ b/email.php
@@ -85,7 +85,7 @@ class EmailPlugin extends Plugin
         $params += array(
             'body' => '{% include "forms/data.html.twig" %}',
             'from' => $this->config->get('plugins.email.from'),
-            'content_type' => null,
+            'content_type' => $this->config->get('plugins.email.content_type'),
             'reply_to' => array(),
             'subject' => !empty($vars['form']) && $vars['form'] instanceof Form ? $vars['form']->page()->title() : null,
             'to' => $this->config->get('plugins.email.to'),

--- a/email.yaml
+++ b/email.yaml
@@ -3,6 +3,8 @@ from:
   mail:
   name:
 to:
+  mail:
+  name:
 mailer:
   engine: mail
   smtp:

--- a/email.yaml
+++ b/email.yaml
@@ -1,5 +1,7 @@
 enabled: true
 from:
+  mail:
+  name:
 to:
 mailer:
   engine: mail


### PR DESCRIPTION
This pull request does the following:

* Made default message content type configurable
* Allowed different types of values for all e-mail related parameters:
  * single e-mail address string
  * array of e-mail address strings
  * single e-mail address definition (array with 'name' and 'mail' keys)
  * multiple e-mail address definitions (each item is an array with 'name' and 'mail' keys or a simple e-mail address string)
* Added support for CC/BCC parameters
* Updated blueprint for extended From/To e-mail addresses with optional name - 

**IMPORTANT NOTE:** This rework produces PHP errors if old config files contain only string values for ```from``` and ```to``` parameters. Due to a different data type now, their values have to be removed manually from ```confing/plugins/email.yaml``` to avoid these problems. Perhaps someone has a better idea on how to solve this?