### PR TITLE
Moved config setting from mailer.default to mailer.engine

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -26,12 +26,8 @@ form:
         type: bool
 
     mailer.engine:
-      label: Mail Engine
-      type: hidden
-
-    mailer.default:
       type: select
-      label: Mailer
+      label: Mail Engine
       size: medium
       options:
         none: Disabled


### PR DESCRIPTION
... while removing ```mailer.default``` completely

This results in validation errors if ```mailer.default``` is still present in ```config/email.yaml```. We should either ignore this (as the value is not used anywhere) or should say something in the ```CHANGELOG.md``` to advice users to remove this settings manually from their ```email.yaml``` file.