### PR TITLE
Added debug option to enable logging on SwiftMailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.3.0
+## 02/27/2016
+
+1. [](#improved)
+    * Added debug option to enable logging on SwiftMailer.
+
 # v2.2.0
 ## 02/05/2016
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -114,3 +114,14 @@ form:
       size: medium
       label: Path to sendmail
       placeholder: "/usr/sbin/sendmail"
+
+    debug:
+      type: toggle
+      label: Debug
+      highlight: 1
+      default: 0
+      options:
+        true: PLUGIN_ADMIN.ENABLED
+        false: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool

--- a/email.php
+++ b/email.php
@@ -182,8 +182,8 @@ class EmailPlugin extends Plugin
                 case 'to':
                     if (is_string($value) && !empty($params['to_name'])) {
                         $value = array(
-                          'mail' => $twig->processString($value, $vars),
-                          'name' => $twig->processString($params['to_name'], $vars),
+                            'mail' => $twig->processString($value, $vars),
+                            'name' => $twig->processString($params['to_name'], $vars),
                         );
                     }
 
@@ -226,8 +226,8 @@ class EmailPlugin extends Plugin
             // Single e-mail address array
             if (!empty($value['mail'])) {
                 $parsed[] = (object) array(
-                  'mail' => $twig->processString($value['mail'], $vars),
-                  'name' => !empty($value['name']) ? $twig->processString($value['name'], $vars) : NULL,
+                    'mail' => $twig->processString($value['mail'], $vars),
+                    'name' => !empty($value['name']) ? $twig->processString($value['name'], $vars) : NULL,
                 );
             }
 

--- a/email.yaml
+++ b/email.yaml
@@ -14,3 +14,4 @@ mailer:
   sendmail:
     bin: '/usr/sbin/sendmail'
 content_type: text/html
+debug: false


### PR DESCRIPTION
As per title, saw a user on Gitter struggling to debug email issues and thought it would be useful to add this as an option.

When enabled, the SwiftMailer conversation is logged and outputted to the grav log as a debug record. 