### PR TITLE
Inherit options from plugin configuration

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -44,6 +44,12 @@ form:
         'text/plain': Plain text
         'text/html': HTML
 
+    charset:
+      type: text
+      size: medium
+      label: Charset
+      placeholder: "Defaults to UTF-8"
+
     from:
       type: email
       size: medium
@@ -74,6 +80,51 @@ form:
       size: medium
       label: Email to name
       placeholder: "Default email to name"
+
+    cc:
+      type: email
+      size: medium
+      label: Email CC
+      placeholder: "Default email CC address"
+      multiple: true
+      validate:
+        type: email
+
+    cc_name:
+      type: text
+      size: medium
+      label: Email CC name
+      placeholder: "Default email CC name"
+
+    bcc:
+      type: email
+      size: medium
+      label: Email BCC
+      placeholder: "Default email BCC address"
+      multiple: true
+      validate:
+        type: email
+
+    reply_to:
+      type: email
+      size: medium
+      label: Email reply-to
+      placeholder: "Default email reply-to address"
+      multiple: true
+      validate:
+        type: email
+
+    reply_to_name:
+      type: text
+      size: medium
+      label: Email reply-to name
+      placeholder: "Default email reply-to name"
+
+    body:
+      type: textarea
+      size: medium
+      label: Email body
+      placeholder: "Defauls to a table of all form fields"
 
     mailer.smtp.server:
       type: text

--- a/email.php
+++ b/email.php
@@ -94,14 +94,14 @@ class EmailPlugin extends Plugin
 
         // Extend parameters with defaults.
         $params += array(
-            'bcc' => array(),
-            'body' => '{% include "forms/data.html.twig" %}',
-            'cc' => array(),
-            'charset' => 'utf-8',
+            'bcc' => $this->config->get('plugins.email.bcc', array()),
+            'body' => $this->config->get('plugins.email.body', '{% include "forms/data.html.twig" %}'),
+            'cc' => $this->config->get('plugins.email.cc', array()),
+            'charset' =>  $this->config->get('plugins.email.charset', 'utf-8'),
             'from' => $this->config->get('plugins.email.from'),
             'from_name' => $this->config->get('plugins.email.from_name'),
             'content_type' => $this->config->get('plugins.email.content_type', 'text/html'),
-            'reply_to' => array(),
+            'reply_to' => $this->config->get('plugins.email.reply_to', array()),
             'subject' => !empty($vars['form']) && $vars['form'] instanceof Form ? $vars['form']->page()->title() : null,
             'to' => $this->config->get('plugins.email.to'),
             'to_name' => $this->config->get('plugins.email.to_name'),

--- a/email.php
+++ b/email.php
@@ -97,11 +97,13 @@ class EmailPlugin extends Plugin
             'bcc' => $this->config->get('plugins.email.bcc', array()),
             'body' => $this->config->get('plugins.email.body', '{% include "forms/data.html.twig" %}'),
             'cc' => $this->config->get('plugins.email.cc', array()),
+            'cc_name' => $this->config->get('plugins.email.cc_name'),
             'charset' =>  $this->config->get('plugins.email.charset', 'utf-8'),
             'from' => $this->config->get('plugins.email.from'),
             'from_name' => $this->config->get('plugins.email.from_name'),
             'content_type' => $this->config->get('plugins.email.content_type', 'text/html'),
             'reply_to' => $this->config->get('plugins.email.reply_to', array()),
+            'reply_to_name' => $this->config->get('plugins.email.reply_to_name'),
             'subject' => !empty($vars['form']) && $vars['form'] instanceof Form ? $vars['form']->page()->title() : null,
             'to' => $this->config->get('plugins.email.to'),
             'to_name' => $this->config->get('plugins.email.to_name'),
@@ -156,6 +158,13 @@ class EmailPlugin extends Plugin
                     break;
 
                 case 'cc':
+                    if (is_string($value) && !empty($params['cc_name'])) {
+                        $value = array(
+                            'mail' => $twig->processString($value, $vars),
+                            'name' => $twig->processString($params['cc_name'], $vars),
+                        );
+                    }
+
                     foreach ($this->parseAddressValue($value, $vars) as $address) {
                         $message->addCc($address->mail, $address->name);
                     }
@@ -175,6 +184,13 @@ class EmailPlugin extends Plugin
                     break;
 
                 case 'reply_to':
+                    if (is_string($value) && !empty($params['reply_to_name'])) {
+                        $value = array(
+                            'mail' => $twig->processString($value, $vars),
+                            'name' => $twig->processString($params['reply_to_name'], $vars),
+                        );
+                    }
+
                     foreach ($this->parseAddressValue($value, $vars) as $address) {
                         $message->addReplyTo($address->mail, $address->name);
                     }

--- a/email.php
+++ b/email.php
@@ -136,6 +136,11 @@ class EmailPlugin extends Plugin
                     }
                     elseif (is_array($value)) {
                         foreach ($value as $body_part) {
+                            $body_part += array(
+                                'charset' => $params['charset'],
+                                'content_type' => $params['content_type'],
+                            );
+
                             $body = !empty($body_part['body']) ? $twig->processString($body_part['body'], $vars) : null;
                             $content_type = !empty($body_part['content_type']) ? $twig->processString($body_part['content_type'], $vars) : null;
                             $charset = !empty($body_part['charset']) ? $twig->processString($body_part['charset'], $vars) : null;


### PR DESCRIPTION
This patch adds the option to configure `cc`, `bcc`, `reply_to`, `body` and `charset` once per site in `user/config/plugins/email.yml`.

In addition, the options `charset` and `content_type` of multiple body parts have the same defaults as if there was only one body part.
