### PR TITLE
add event hook before mailing

### DIFF
--- a/email.php
+++ b/email.php
@@ -1,6 +1,7 @@
 <?php
 namespace Grav\Plugin;
 
+use Grav\Common\Grav;
 use Grav\Common\Plugin;
 use Grav\Common\Twig\Twig;
 use Grav\Plugin\Email\Email;
@@ -70,6 +71,9 @@ class EmailPlugin extends Plugin
                 $vars = array(
                     'form' => $form
                 );
+
+                $grav = Grav::instance();
+                $grav->fireEvent('onEmailSend', new Event(['params' => &$params, 'vars' => &$vars]));
 
                 // Build message
                 $message = $this->buildMessage($params, $vars);


### PR DESCRIPTION
Working Example for #66, based on https://github.com/getgrav/grav-plugin-admin/blob/2d70928e2d575c0b9676c270a7c3f44018498ba1/classes/admin.php#L213 . 

As for what a plugin usable to alter recipients could look like: https://github.com/BootedWeb/grav-mail-event-hook-plugin.