### PR TITLE
make email configuration available to templates

### DIFF
--- a/classes/Email.php
+++ b/classes/Email.php
@@ -171,6 +171,11 @@ class Email
             throw new \RuntimeException($language->translate('PLUGIN_EMAIL.PLEASE_CONFIGURE_A_FROM_ADDRESS'));
         }
 
+        // make email configuration available to templates
+        $vars += [
+            'email' => $params,
+        ];
+
         // Process parameters.
         foreach ($params as $key => $value) {
             switch ($key) {


### PR DESCRIPTION
I am making the email configuration available to eg. the template processing.
My use case is to adjust the email signature based on the from address. And as far as I can see, there is no way to do this right now.