### PR TITLE
fix readme: environment test

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ $ bin/plugin email test-email -t steve@apple.com
 You can also pass in a configuration environment:
 
 ```
-$ bin/plugin email test-email -t steve@apple.com -e mysite.com
+$ bin/plugin email test-email -t steve@apple.com --env mysite.com
 ```
 
 This will use the email configuration you have located in `user/mysite.com/config/plugins/email.yaml`. Read the docs to find out more about environment-based configuration: https://learn.getgrav.org/advanced/environment-config


### PR DESCRIPTION
When I called `bin/plugin email test-email -t steve@apple.com -e mysite.com`, I got error: 

```none


  The "-e" option does not exist.


test-email [-t|--to TO] [-s|--subject [SUBJECT]] [-b|--body [BODY]] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [--env [ENV]] [--lang [LANG]] [--] <command>

```