### PR TITLE
Fix email name check

### DIFF
--- a/classes/Email.php
+++ b/classes/Email.php
@@ -260,7 +260,7 @@ class Email
                             $list[] = $this->createAddress($recipient);
                         }
                     } else {
-                        if (!Utils::contains($recipients, ['<','>']) && ($params[$type."_name"])) {
+                        if (!Utils::contains($recipients, ['<','>']) && !empty($params[$type."_name"])) {
                             $recipients = [$recipients, $params[$type."_name"]];
                         }
                         $list[] = $this->createAddress($recipients);


### PR DESCRIPTION
Without this check, it causes a Critical Grav error (which should be just a warning IMO) of undefined index and prevents whole form email action process. Usually name is not required and often not known. In my specific case, it was with the `bcc` config and undefined index was `bcc_name`